### PR TITLE
Fix spacing of port cells

### DIFF
--- a/index.html
+++ b/index.html
@@ -100,53 +100,53 @@
     <div class="container">
       <h3>Ports</h3>
       <div class="row">
-        <div class="col-2 port">
+        <div class="col-3 port">
           <span class="icon"><i class="ri-vimeo-fill has-text-green"></i></span>
           <a href="https://github.com/embark-theme/vim" class="has-text-white">Vim</a>
         </div>
-        <div class="col-2 port">
+        <div class="col-3 port">
           <span class="icon">
             <i class="ri-terminal-box-fill has-text-yellow"></i>
           </span>
           <a href="https://github.com/embark-theme/kitty" class="has-text-white">Kitty</a>
         </div>
-        <div class="col-2 port">
+        <div class="col-3 port">
           <span class="icon">
             <i class="ri-rocket-2-fill has-text-red"></i>
           </span>
           <a href="https://github.com/embark-theme/alacritty" class="has-text-white">Alacritty</a>
         </div>
-        <div class="col-2 port">
+        <div class="col-3 port">
           <span class="icon">
             <i class="ri-terminal-box-fill has-text-cyan"></i>
           </span>
           <a href="https://github.com/embark-theme/iterm" class="has-text-white">iTerm</a>
         </div>
-        <div class="col-2 port">
+        <div class="col-3 port">
           <span class="icon">
             <i class="ri-firefox-fill has-text-dark-yellow"></i>
           </span>
           <a href="https://github.com/embark-theme/firefox" class="has-text-white">firefox</a>
         </div>
-        <div class="col-2 port">
+        <div class="col-3 port">
           <span class="icon">
             <i class="ri-bar-chart-fill has-text-purple"></i>
           </span>
           <a href="https://github.com/embark-theme/bashtop" class="has-text-white">Bashtop</a>
         </div>
-        <div class="col-2 port">
+        <div class="col-3 port">
           <span class="icon">
             <i class="ri-bar-chart-fill has-text-purple"></i>
           </span>
           <a href="https://github.com/embark-theme/bashtop" class="has-text-white">Bpytop</a>
         </div>
-        <div class="col-2 port">
+        <div class="col-3 port">
           <span class="icon">
             <i class="ri-file-pdf-fill has-text-white"></i>
           </span>
           <a href="https://github.com/embark-theme/zathura" class="has-text-white">Zathura</a>
         </div>
-        <div class="col-2 port">
+        <div class="col-3 port">
           <span class="icon">
             <i class="ri-eye-2-fill has-text-purple"></i>
           </span>


### PR DESCRIPTION
On some screen sizes the icons and titles were wrapping weird. This grid size seems to hold up better to more screen sizes.